### PR TITLE
Escapes CSS to deal with case when an element has a numerical ID

### DIFF
--- a/js/shared/utils.js
+++ b/js/shared/utils.js
@@ -284,7 +284,7 @@ class NodeUtils {
 			if (node.nodeType === Node.ELEMENT_NODE && node.id.length > 0) {
 				// if the node is an element with a unique id within the *document*, it can become the root of the path,
 				// and since we're going from node to document root, we have all we need.
-				if (node.ownerDocument.querySelectorAll(`#${node.id}`).length === 1) {
+				if (node.ownerDocument.querySelectorAll(`#${CSS.escape(node.id)}`).length === 1) {
 					// because the first item of the path array is prefixed with '/', this will become 
 					// a double slash (select all elements). But as there's only one result, we can use [1]
 					// eg: //span[@id='something']/div[3]/text()


### PR DESCRIPTION
This PR updates utils.js to add CSS escaping to querySelectorAll. This is to deal with the case when the ID of the element starts with a numerical value, e.g. 2cdb. Try out super simple highligher on [this article](https://medium.com/airbnb-engineering/how-airbnb-democratizes-data-science-with-data-university-3eccc71e073a) and you'll see the code erroring in the console when you try and highlight.

CSS escape seems to be [compatible](https://caniuse.com/mdn-api_css_escape) with all modern browsers.